### PR TITLE
New adhoc parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ FXLauncher can also be used to launch an application at an arbitrary url by spec
 java -jar fxlauncher.jar --app=http://remote/location/app.xml
 ```
 
+Alternatively (or in combination with `--app...`), you can override the uri attribute in the manifest (`app.xml`) so that both `app.xml` and all resources are loaded from the specified uri. This is especially useful for testing the complete setup locally or from a staging environment.
+
+```bash
+java -jar fxlauncher.jar --uri=http://remote/location/
+```
+
+The two parameters also work in tandem, allowing you to load a specified manifest from one URL and override its uri.
+
+```bash
+java -jar fxlauncher.jar --app=http://remote/location/app.xml --uri=http://remote/location/
+```
+
+Note: All parameters (including these) are passed on to your application.  So please ensure that your parameters have a different name if they carry different data.
+
 #### Native installers
 
 The native installer does not contain any application code, only the launcher. There is

--- a/src/main/java/fxlauncher/Launcher.java
+++ b/src/main/java/fxlauncher/Launcher.java
@@ -228,10 +228,32 @@ public class Launcher extends Application {
     private void syncManifest() throws Exception {
         Map<String, String> namedParams = getParameters().getNamed();
 
+        String appStr = null;
+
         if (namedParams.containsKey("app")) {
-            String manifestURL = namedParams.get("app");
-            log.info(String.format("Loading manifest from parameter supplied location %s", manifestURL));
-            manifest = FXManifest.load(URI.create(manifestURL));
+            // get --app-param
+            appStr = namedParams.get("app");
+            log.info(String.format("Loading manifest from 'app' parameter supplied: %s", appStr));
+        }
+
+        if (namedParams.containsKey("uri")) {
+            // get --uri-param
+            String uriStr  = namedParams.get("uri");
+            if (! uriStr.endsWith("/")) { uriStr = uriStr + "/"; }
+            log.info(String.format("Syncing files from 'uri' parameter supplied:  %s", uriStr));
+
+            URI uri = URI.create(uriStr);
+            // load manifest from --app param if supplied, else default file at supplied uri
+            URI app = appStr != null ? URI.create(appStr) : uri.resolve("app.xml");
+            manifest = FXManifest.load(app);
+            // set supplied uri in manifest
+            manifest.uri = uri;
+            return;
+        }
+
+        if (appStr != null) {
+            // --uri was not supplied, but --app was, so load manifest from that
+            manifest = FXManifest.load(URI.create(appStr));
             return;
         }
 
@@ -250,14 +272,15 @@ public class Launcher extends Application {
             if (remoteManifest == null) {
                 log.info(String.format("No remote manifest at %s", manifest.getFXAppURI()));
             } else if (!remoteManifest.equals(manifest)) {
-                // Update to remote manifest if newer or we specifially accept downgrades
+                // Update to remote manifest if newer or we specifically accept downgrades
                 if (remoteManifest.isNewerThan(manifest) || manifest.acceptDowngrade) {
                     manifest = remoteManifest;
                     JAXB.marshal(manifest, manifestPath.toFile());
                 }
             }
         } catch (Exception ex) {
-            log.log(Level.WARNING, "Unable to update manifest", ex);
+            log.log(Level.WARNING,
+                    String.format("Unable to update manifest from %s", manifest.getFXAppURI()), ex);
         }
     }
 


### PR DESCRIPTION
Added new parameter 'uri'  which overrides the 'uri' in manifest - allowing complete run against arbitrary uri.  It can optionally works in conjunction with 'app' param, allowing running from the specified manifest, and also overriding its uri attribute.

Code is commented.
Readme is updated. 