### PR TITLE
new mutex parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 # Created by .ignore support plugin (hsz.mobi)
+/.idea/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ java -jar fxlauncher.jar --app=http://remote/location/app.xml --uri=http://remot
 
 Note: All parameters (including these) are passed on to your application.  So please ensure that your parameters have a different name if they carry different data.
 
+
+You can also override the mutex setting in the manifest.
+This is useful if you wish run multiple instances of your application, but have set a mutex.
+ 
+To set a mutex:
+```bash
+java -jar fxlauncher.jar --mutex=MyAppMutexName
+```
+
+To remove the embedded mutex:
+```bash
+java -jar fxlauncher.jar --mutex=  # no value
+```
+
+See more on mutex bellow.
+
 #### Native installers
 
 The native installer does not contain any application code, only the launcher. There is
@@ -101,6 +117,22 @@ Starting from version 1.0.12, FXLauncher will not download a remote version if t
 by comparing a timestamp in the manifest. Specifying `--accept-downgrades=true` as the last argument to CreateManifest will
 allow you to make sure that the version you have published will always be used by your clients even if they have a newer version installed.
 This option is also available in the Gradle plugin as `acceptDowngrades`.
+
+## Mutex
+
+Starting with version 1.0.15, FXLauncher can ensure that only a single instance of your app will run.  Specifying `--mutex=MyAppMutexName` ensures a single instance only.
+
+This parameter can be overridden adhoc. (See above.)
+An empty value is equivalent to no mutex ( `--mutex=` ).
+
+A lock is aquired by that name, by the first instance to run, and removed when that instance exits. If subsequent instances are attempted, they will fail to aquire a lock and exit silently (with log-entry) as soon as they have loaded their manifest.
+
+The lock is per-user on a shared system, allowing each user to run a single instance each.
+
+This app mutex implementation uses [JUnique](https://github.com/terjedahl/junique) under the hood.  
+Regarding choice of mutex name: 
+ > To avoid potential conflicts, it is advisable to choose a fully qualifying lock ID for each application using JUnique. Using a generic ID, such "notepad", "chat" or "myapp", is not a good idea. Better to use something like "myName.myAppName", and even better it's to pick your application main class full name as the JUnique lock ID.
+
 
 ## A slimmer alternative
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,23 @@
         <url>git@github.com:edvin/fxlauncher.git</url>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>github-terjedahl-junique</id>
+            <name>GitHub TerjeDahl JUnique</name>
+            <!--<url>https://github.com/terjedahl/junique/tree/master/maven2</url>-->
+            <url>https://raw.githubusercontent.com/terjedahl/junique/master/maven2</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>it.sauronsoftware</groupId>
+            <artifactId>junique</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -84,6 +101,36 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <!--
+Builds an "uberjar" (jar with dependencies included).
+When appendAsemblyId=false, the uberjar will get the same name as the original jar, thereby replacing it (and making it backwards compatible).
+             -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>fxlauncher.Launcher</mainClass>
+                        </manifest>
+                    </archive>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/fxlauncher/CreateManifest.java
+++ b/src/main/java/fxlauncher/CreateManifest.java
@@ -26,6 +26,7 @@ public class CreateManifest {
         Path appPath = Paths.get(args[2]);
 
         String cacheDir = null;
+        String mutex = null;
         Boolean acceptDowngrade = null;
         String parameters = null;
         String preloadNativeLibraries = null;
@@ -41,6 +42,10 @@ public class CreateManifest {
                 // Configure cacheDir
                 if (named.containsKey("cache-dir"))
                     cacheDir = named.get("cache-dir");
+
+                // If empty string or null, then not isMutex
+                if (named.containsKey("mutex"))
+                    mutex = named.get("mutex");
 
                 // Configure acceptDowngrade
                 if (named.containsKey("accept-downgrade"))
@@ -66,6 +71,7 @@ public class CreateManifest {
                 if (raw.startsWith("--accept-downgrade=")) continue;
                 if (raw.startsWith("--include-extensions=")) continue;
                 if (raw.startsWith("--preload-native-libraries=")) continue;
+                if (raw.startsWith("--mutex=")) continue;
                 if (rest.length() > 0) rest.append(" ");
                 rest.append(raw);
             }
@@ -77,6 +83,7 @@ public class CreateManifest {
 
         FXManifest manifest = create(baseURI, launchClass, appPath);
         if (cacheDir != null) manifest.cacheDir = cacheDir;
+        if (mutex != null) manifest.mutex = mutex;
         if (acceptDowngrade != null) manifest.acceptDowngrade = acceptDowngrade;
         if (parameters != null) manifest.parameters = parameters;
         if (preloadNativeLibraries != null) manifest.preloadNativeLibraries = preloadNativeLibraries;

--- a/src/main/java/fxlauncher/FXManifest.java
+++ b/src/main/java/fxlauncher/FXManifest.java
@@ -38,6 +38,8 @@ public class FXManifest {
 	@XmlElement
 	public String cacheDir;
 	@XmlElement
+	public String mutex;
+	@XmlElement
 	public Boolean acceptDowngrade = false;
 	@XmlElement
 	public String preloadNativeLibraries;
@@ -108,6 +110,17 @@ public class FXManifest {
 		return path;
 	}
 
+	public String getMutex() {
+		if (mutex == null)
+			return null;
+		return mutex.trim();
+	}
+
+	public boolean isMutex() {
+		String name = getMutex();
+		return (name != null && !name.isEmpty());
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -125,6 +138,7 @@ public class FXManifest {
 		if (wrapperStyle != null ? !wrapperStyle.equals(that.wrapperStyle) : that.wrapperStyle != null) return false;
 		if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
 		if (cacheDir != null ? !cacheDir.equals(that.cacheDir) : that.cacheDir != null) return false;
+		if (mutex != null ? mutex.equals(that.mutex) : that.mutex != null) return false;
 		return acceptDowngrade != null ? acceptDowngrade.equals(that.acceptDowngrade) : that.acceptDowngrade == null;
 
 	}
@@ -141,6 +155,7 @@ public class FXManifest {
 		result = 31 * result + (wrapperStyle != null ? wrapperStyle.hashCode() : 0);
 		result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
 		result = 31 * result + (cacheDir != null ? cacheDir.hashCode() : 0);
+		result = 31 * result + (mutex != null ? mutex.hashCode() : 0);
 		result = 31 * result + (acceptDowngrade != null ? acceptDowngrade.hashCode() : 0);
 		return result;
 	}

--- a/src/main/java/fxlauncher/UIProvider.java
+++ b/src/main/java/fxlauncher/UIProvider.java
@@ -38,7 +38,7 @@ public interface UIProvider {
 
 	/**
 	 * Create the Node that will be displayed while the launcher is loading resources,
-	 * before the update process starts. The default implementation is an intdeterminate
+	 * before the update process starts. The default implementation is an indeterminate
 	 * progress indicator, but you can return any arbitrary scene graph.
 	 *
 	 * @return The launcher UI
@@ -52,6 +52,7 @@ public interface UIProvider {
 	 * method is called.
 	 *
 	 * @see #updateProgress(double)
+	 * @param manifest The manifest instance. Allows implementing class access to all manifest attributes.
 	 * @return The updater Node
 	 */
 	Parent createUpdater(FXManifest manifest);


### PR DESCRIPTION
Added new parameter 'mutex' - both in manifest and as adhoc (which overrides manifest).
By specifying a mutex-parameter (string), a per-user single-instance lock is acquired, ensuring only a single instance is run (per user).  An empty string is synonymous with no-mutex, allowing for override adhoc ('--mutex=').
Functionality is implemented with JUnique.
JUnique is (at present) served from GitHub.
JUnique is packaged into the JAR.
pom.xml has been updated accordingly.
Code is commented.
Readme is updated.