### PR TITLE
alternative classloader strategy

### DIFF
--- a/src/main/java/fxlauncher/FxlauncherClassCloader.java
+++ b/src/main/java/fxlauncher/FxlauncherClassCloader.java
@@ -1,0 +1,68 @@
+package fxlauncher;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by im on 22.02.17.
+ */
+public class FxlauncherClassCloader extends URLClassLoader
+{
+    public FxlauncherClassCloader(ClassLoader parentClassLoader)
+    {
+        super(buildClasspath(System.getProperty("java.class.path")), parentClassLoader);
+    }
+
+    void addUrls(List<URL> urls)
+    {
+        for (URL url : urls)
+        {
+            this.addURL(url);
+        }
+    }
+
+    private static URL[] buildClasspath(String classPath)
+    {
+        if (classPath == null || classPath.trim().length() < 1)
+        {
+            return new URL[0];
+        }
+
+        List<URL> urls = new ArrayList<>();
+
+        int pos;
+        while ((pos = classPath.indexOf(File.pathSeparatorChar)) > -1)
+        {
+            String part = classPath.substring(0, pos);
+
+            addClasspathPart(urls, part);
+
+            classPath = classPath.substring(pos + 1);
+        }
+
+        addClasspathPart(urls, classPath);
+
+        return urls.toArray(new URL[urls.size()]);
+    }
+
+    private static void addClasspathPart(List<URL> urls, String part)
+    {
+        if (part == null || part.trim().length() < 1)
+        {
+            return;
+        }
+
+        try
+        {
+            urls.add(new File(part).toURI().toURL());
+        }
+        catch (MalformedURLException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Alternatively to creating a classloader for the application at runtime, allow to configure at fxlauncher classloader at boot-time and add the new classpath-entries to this classloader.
This should avoid problems where the jdk itself uses Class.forName (e.g. URLStreamHandler stuff) and might not find application-classes due to using the wrong classloader.

To activate this classloader one needs to add
-Djava.system.class.loader=fxlauncher.FxlauncherClassCloader
to the fxlauncher startup.
Without this argument the current behavior is still in place.

