### PR TITLE
Feature to validate certificate for a SSL connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,14 @@
     <description>Auto updating launcher for JavaFX Applications</description>
     <url>https://github.com/edvin/fxlauncher</url>
 
+	<dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+    </dependencies>
+
     <distributionManagement>
         <repository>
             <id>sonatype-nexus-staging</id>
@@ -76,13 +84,28 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                     <archive>
                         <manifest>
                             <mainClass>fxlauncher.Launcher</mainClass>
                         </manifest>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/fxlauncher/CertificateInKeystoreTrustStrategy.java
+++ b/src/main/java/fxlauncher/CertificateInKeystoreTrustStrategy.java
@@ -1,0 +1,44 @@
+package fxlauncher;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.conn.ssl.TrustStrategy;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.logging.Logger;
+
+public class CertificateInKeystoreTrustStrategy implements TrustStrategy {
+
+    private static final Logger log = Logger.getLogger("CertificateInKeystoreTrustStrategy");
+    private String certDigest;
+    private String alias;
+    private KeyStore keyStore;
+
+    public CertificateInKeystoreTrustStrategy(String certDigest, String alias, KeyStore keyStore) {
+        this.certDigest = certDigest;
+        this.alias = alias;
+        this.keyStore = keyStore;
+    }
+
+    @Override
+    public boolean isTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        try {
+            log.info("Comparing the expected and actual certificates");
+            X509Certificate cert = this.keyStore != null ? (X509Certificate) this.keyStore.getCertificate(this.alias) : null;
+            String actualCert;
+            if (x509Certificates == null || x509Certificates.length == 0)
+                throw new RuntimeException("err-server-presented-no-certificates");
+            else if(!(actualCert = DigestUtils.sha1Hex(x509Certificates[0].getEncoded())).equals(this.certDigest)) {
+                log.info("Unexpected certificate certdigest found: "+this.certDigest+" actual:: "+actualCert);
+                log.info("Presented certificate is "+x509Certificates[0]);
+                throw new RuntimeException("err-https-certificate-mismatch");
+            }
+            return cert == null || (cert == x509Certificates[0]);
+        }
+        catch(KeyStoreException kse) {
+            throw new RuntimeException("err-ketStore-not-found");
+        }
+    }
+}

--- a/src/main/java/fxlauncher/CreateManifest.java
+++ b/src/main/java/fxlauncher/CreateManifest.java
@@ -28,6 +28,7 @@ public class CreateManifest {
         Path appPath = Paths.get(args[2]);
 
         String cacheDir = null;
+        String certDigest = null;
         Boolean acceptDowngrade = null;
         String parameters = null;
         String whatsNew = null;
@@ -45,6 +46,10 @@ public class CreateManifest {
                 // Configure cacheDir
                 if (named.containsKey("cache-dir"))
                     cacheDir = named.get("cache-dir");
+
+                // Configure certDigest
+                if (named.containsKey("cert-digest"))
+                    certDigest = named.get("cert-digest");
 
                 // Configure acceptDowngrade
                 if (named.containsKey("accept-downgrade"))
@@ -75,6 +80,7 @@ public class CreateManifest {
             StringBuilder rest = new StringBuilder();
             for (String raw : params.getRaw()) {
                 if (raw.startsWith("--cache-dir=")) continue;
+                if (raw.startsWith("--cert-digest=")) continue;
                 if (raw.startsWith("--accept-downgrade=")) continue;
                 if (raw.startsWith("--include-extensions=")) continue;
                 if (raw.startsWith("--preload-native-libraries=")) continue;
@@ -91,6 +97,7 @@ public class CreateManifest {
 
         FXManifest manifest = create(baseURI, launchClass, appPath);
         if (cacheDir != null) manifest.cacheDir = cacheDir;
+        if (certDigest != null) manifest.certDigest = certDigest;
         if (acceptDowngrade != null) manifest.acceptDowngrade = acceptDowngrade;
         if (parameters != null) manifest.parameters = parameters;
         if (preloadNativeLibraries != null) manifest.preloadNativeLibraries = preloadNativeLibraries;

--- a/src/main/java/fxlauncher/FXManifest.java
+++ b/src/main/java/fxlauncher/FXManifest.java
@@ -38,6 +38,8 @@ public class FXManifest {
 	@XmlElement
 	public String cacheDir;
 	@XmlElement
+	public String certDigest;
+	@XmlElement
 	public Boolean acceptDowngrade = false;
 	@XmlElement
 	public String preloadNativeLibraries;
@@ -113,6 +115,11 @@ public class FXManifest {
 		return path;
 	}
 
+	public String resolveCertDigestStr(Map<String, String> namedParams) {
+		if (namedParams == null) namedParams = Collections.emptyMap();
+		return namedParams.containsKey("cert-digest") ? namedParams.get("cert-digest") : this.certDigest;
+	}
+
 	public String getWhatsNewPage()
 	{
 		return whatsNewPage;
@@ -135,6 +142,7 @@ public class FXManifest {
 		if (wrapperStyle != null ? !wrapperStyle.equals(that.wrapperStyle) : that.wrapperStyle != null) return false;
 		if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
 		if (cacheDir != null ? !cacheDir.equals(that.cacheDir) : that.cacheDir != null) return false;
+		if (certDigest != null ? !certDigest.equals(that.certDigest) : that.certDigest != null) return false;
 		if (lingeringUpdateScreen != null ? !lingeringUpdateScreen.equals(that.lingeringUpdateScreen) : that.lingeringUpdateScreen != null) return false;
 		return acceptDowngrade != null ? acceptDowngrade.equals(that.acceptDowngrade) : that.acceptDowngrade == null;
 	}
@@ -151,6 +159,7 @@ public class FXManifest {
 		result = 31 * result + (wrapperStyle != null ? wrapperStyle.hashCode() : 0);
 		result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
 		result = 31 * result + (cacheDir != null ? cacheDir.hashCode() : 0);
+		result = 31 * result + (certDigest != null ? certDigest.hashCode() : 0);
 		result = 31 * result + (acceptDowngrade != null ? acceptDowngrade.hashCode() : 0);
 		return result;
 	}


### PR DESCRIPTION
Custom TrustManager for validating cert digest
Linked to:
[https://github.com/edvin/fxldemo-gradle/issues/8](url)

This is implemented as the cacheDir parameter.

Couple of concerns:
1) I have added a new dependency of httpclient v4.5.2 because of which in the pom.xml I had to add maven-assembly-plugin which creates an executable jar with this string appended at the last of the jar name "-jar-with-dependencies". So the maven now basically installs two jars; one fxlauncher-1.0.17-SNAPSHOT.jar and one fxlauncher-1.0.17-SNAPSHOT-jar-with-dependencies.jar. The second jar needs to be referenced by the project fxlauncher-gradle-plugin.
2) I wanted to add a HttpsURLConnection.setDefaultHostnameVerifier() which basically would verify the hostname of the connecting url and the hostname from the "applicationUrl" specified in the gradle build. But I was not able to do it as the HostnameVerifier gets ignored (don't know why.) Should this be present ? Please let me know if you have a way of implementing this. Even if not implemented, this works fine.
