### PR TITLE
Adding Support for UNC paths for App URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,13 @@ Notice: `WhatsNew` is not supported.
 
 ### File based deployment
 
-The app uri can be a file:// based url instead of an web uri if your application is hosted on a common network location for your users.
+The app uri can be a `file://` based url instead of a web uri if your application is hosted on a common network location for your users.
+
+#### UNC Paths
+FXLauncher can deal with [UNC paths], if you ask it nicely. Instead of `\\server\share\myapp` use `file:////server/share/myapp`.
+Yes, that's four forward slashes; two for the `file://` protocol and two for the UNC path.
+
+[UNC paths]: https://www.lifewire.com/unc-universal-naming-convention-818230
 
 ### Native installers
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,26 @@ Check out these prebuilt installers for a more complex demo application
 
 ## Specify cache directory
 
-By default, the artifacts are downloaded to the current working directory. This is usually fine for native installers, but if you distribute
-your application via just the launcher jar, you might want to specify where the downloaded artifacts land. See the 
-[cache dir documentation](https://github.com/edvin/fxlauncher/wiki/Optional-Cache-Directory) for more information.
+By default, the artifacts are downloaded to the current working directory. This is usually fine for per-user native 
+installers, but if you distribute your application via a system-wide native installer, or just the launcher 
+jar, you might want to specify where the downloaded artifacts land. See the 
+[cache dir documentation] for more information.
+
+[cache dir documentation]: https://github.com/edvin/fxlauncher/wiki/Optional-Cache-Directory
 
 ## Installation location
 
-It's worth noting that the two package alternatives for Windows, (EXE and MSI) have different install location defaults.
-While EXE will default to %APPDATALOCAL%, the MSI installer will default to %ProgramFiles%. If you use the MSI installer you
-might therefore need to specify the cache dir parameter as `cacheDir 'USERLIB/MyApp'` to make sure that the launcher has
-write access to download the artifacts for your application.
+It's worth noting that the two package alternatives for Windows, (EXE and MSI) have different default install locations.
+While EXE will default to [`%AppDataLocal%`], the MSI installer will default to `%ProgramFiles%`.  To write to 
+`%ProgramFiles%` one definitely does need admin privileges—that poses a problem for FXLauncher which, by default, 
+downloads updates to where it was installed. 
+
+If you use the MSI installer you will therefore need to tell FXLauncher to cache artifacts somewhere it is allowed
+to put them. For an OS-independent answer to this problem, look no further than the 
+[two magical strings][cache dir documentation], `USERLIB` and `ALLUSERS`. 
+
+
+[`%AppDataLocal%`]: https://www.howtogeek.com/318177/what-is-the-appdata-folder-in-windows/
 
 Read more about Java Packager in the official documentation:
 

--- a/src/main/java/fxlauncher/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/AbstractLauncher.java
@@ -125,7 +125,15 @@ public abstract class AbstractLauncher<APP>  {
             Path target = cacheDir.resolve(lib.file).toAbsolutePath();
             Files.createDirectories(target.getParent());
 
-            URI uri = manifest.uri.resolve(lib.file);
+            URI uri;
+            if (!manifest.uri.getPath().endsWith("/")) {
+                // We avoid using resolve here so as to not break UNC paths. See issue #143
+                uri = URI.create(manifest.uri.toString() + "/" + lib.file);
+            } else {
+                // We avoid using resolve here so as to not break UNC paths. See issue #143
+                uri = URI.create(manifest.uri.toString() + lib.file);
+            }
+
 
             try (InputStream input = openDownloadStream(uri); OutputStream output = Files.newOutputStream(target)) {
 

--- a/src/main/java/fxlauncher/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/AbstractLauncher.java
@@ -192,9 +192,15 @@ public abstract class AbstractLauncher<APP>  {
             }
             log.info(String.format("Syncing files from 'uri' parameter supplied:  %s", uriStr));
 
+            if (!uriStr.endsWith("/")) {
+                uriStr += "/";
+            }
             URI uri = URI.create(uriStr);
+
             // load manifest from --app param if supplied, else default file at supplied uri
-            URI app = appStr != null ? URI.create(appStr) : uri.resolve("app.xml");
+            URI app = (appStr != null)
+                    ? URI.create(appStr)
+                    : URI.create(uriStr + "app.xml"); // We avoid using resolve here so as to not break UNC paths. See issue #143
             manifest = FXManifest.load(app);
             // set supplied uri in manifest
             manifest.uri = uri;

--- a/src/main/java/fxlauncher/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/AbstractLauncher.java
@@ -127,10 +127,10 @@ public abstract class AbstractLauncher<APP>  {
 
             URI uri;
             if (!manifest.uri.getPath().endsWith("/")) {
-                // We avoid using resolve here so as to not break UNC paths. See issue #143
+                // We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
                 uri = URI.create(manifest.uri.toString() + "/" + lib.file);
             } else {
-                // We avoid using resolve here so as to not break UNC paths. See issue #143
+                // We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
                 uri = URI.create(manifest.uri.toString() + lib.file);
             }
 
@@ -208,7 +208,7 @@ public abstract class AbstractLauncher<APP>  {
             // load manifest from --app param if supplied, else default file at supplied uri
             URI app = (appStr != null)
                     ? URI.create(appStr)
-                    : URI.create(uriStr + "app.xml"); // We avoid using resolve here so as to not break UNC paths. See issue #143
+                    : URI.create(uriStr + "app.xml"); // We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
             manifest = FXManifest.load(app);
             // set supplied uri in manifest
             manifest.uri = uri;

--- a/src/main/java/fxlauncher/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/AbstractLauncher.java
@@ -126,13 +126,10 @@ public abstract class AbstractLauncher<APP>  {
             Files.createDirectories(target.getParent());
 
             URI uri;
-            if (!manifest.uri.getPath().endsWith("/")) {
-                // We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
-                uri = URI.create(manifest.uri.toString() + "/" + lib.file);
-            } else {
-                // We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
-                uri = URI.create(manifest.uri.toString() + lib.file);
-            }
+
+            // We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
+            String separator = manifest.uri.getPath().endsWith("/") ? "" : "/";
+            uri = URI.create(manifest.uri.toString() + separator + lib.file);
 
 
             try (InputStream input = openDownloadStream(uri); OutputStream output = Files.newOutputStream(target)) {

--- a/src/main/java/fxlauncher/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/AbstractLauncher.java
@@ -189,6 +189,10 @@ public abstract class AbstractLauncher<APP>  {
             log.info(String.format("Loading manifest from 'app' parameter supplied: %s", appStr));
         }
 
+        if (appStr != null && !appStr.endsWith("/")) {
+            appStr += "/";
+        }
+
         if (namedParams.containsKey("uri")) {
             // get --uri-param
             String uriStr = namedParams.get("uri");

--- a/src/main/java/fxlauncher/FXManifest.java
+++ b/src/main/java/fxlauncher/FXManifest.java
@@ -65,10 +65,13 @@ public class FXManifest {
 	}
 
 	public URI getFXAppURI() {
-		if (uri.getPath().endsWith("/"))
-			return uri.resolve("app.xml");
+		String appXmlFile = "app.xml";
+		if (!uri.getPath().endsWith("/")) {
+			appXmlFile = "/app.xml";
+		}
 
-		return URI.create(uri.toString() + "/app.xml");
+		// We avoid using resolve here so as to not break UNC paths. See issue #143
+		return URI.create(uri.toString() + appXmlFile);
 	}
 
 	public Path getPath(Path cacheDir) {

--- a/src/main/java/fxlauncher/FXManifest.java
+++ b/src/main/java/fxlauncher/FXManifest.java
@@ -70,7 +70,7 @@ public class FXManifest {
 			appXmlFile = "/app.xml";
 		}
 
-		// We avoid using resolve here so as to not break UNC paths. See issue #143
+		// We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
 		return URI.create(uri.toString() + appXmlFile);
 	}
 

--- a/src/main/java/fxlauncher/FXManifest.java
+++ b/src/main/java/fxlauncher/FXManifest.java
@@ -65,13 +65,11 @@ public class FXManifest {
 	}
 
 	public URI getFXAppURI() {
-		String appXmlFile = "app.xml";
-		if (!uri.getPath().endsWith("/")) {
-			appXmlFile = "/app.xml";
-		}
+
+		String separator = uri.getPath().endsWith("/") ? "" : "/";
 
 		// We avoid using uri.resolve() here so as to not break UNC paths. See issue #143
-		return URI.create(uri.toString() + appXmlFile);
+		return URI.create(uri.toString() + separator + "app.xml");
 	}
 
 	public Path getPath(Path cacheDir) {


### PR DESCRIPTION
Well, I'm quite new at this.

In the following commits, I went and sought out each usage of `uri.resolve()` and changed it to use instead `URI.create()`. The reason for this is that `uri.resolve()` calls `uri.normalize()` and `uri.normalize()` breaks UNC paths, as described in greater detail in Issue #143.

It sure took me some doing to test it. I tried to include my edited version as a dependency to a test project, but the gradle plugin, kind of ignored that and used the version it was configured to use. If possible it would be nice to make the gradle plugin more friendly to to using a specifiable version of fxlauncher (maybe it already it is, and I just don't know how). 

I ended up cloning the gradle plugin repo, too, then I realized I needed a Groovy SDK, so I installed a Groovy SDK. Then I tried to change the fxlauncherVersion to the custom one I built, but then I couldn't figure out how to get the plugin to install itself into my Local Maven Repository.  Running the install task resulted in 

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':signArchives'.
> Cannot perform signing task ':signArchives' because it has no config
ured signatory

* Try:
Run with --stacktrace option to get the stack trace. Run with --info o
r --debug option to get more log output.

BUILD FAILED


```


So I tried to manually install it, by copying over the jar myself. (Any advice on how I could've gotten the plugin to install itself is welcome. Did I need to disable the signArchives task somehow? AM I DOING ANY OF THIS RIGHT? :sweat_smile: )

Regardless, I finally had a custom fxlauncher and then a custom gradle plugin, and I built my test app and... it worked! It pulled from a UNC path, no problems!

But yeah, I new at this, so do take a good hard look, and please do let me know how I *should* have done it.