### PR TITLE
add compile time dependencies for Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,14 +129,52 @@
         </plugins>
     </build>
 
-    <dependencies>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-    </dependencies>
-
+    <profiles>
+        <!-- Java 9/10: java.xml.bind is needed -->
+        <profile>
+            <id>Java9</id>
+            <activation>
+                <jdk>[9,10]</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>2.3.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <!-- Java 11+: java.xml.bind and JavaFX -->
+        <profile>
+            <id>Java11+</id>
+            <activation>
+                <jdk>![1.8,9,10]</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>2.3.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-controls</artifactId>
+                    <version>11.0.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-fxml</artifactId>
+                    <version>11.0.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-web</artifactId>
+                    <version>11.0.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+ 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,14 @@
         </plugins>
     </build>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+    </dependencies>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
This adds the java.xml.bind dependency for Java 9+ and also JavaFX for JDK 11+. I can now compile FXLauncher under both JDK 8 and 11. The resulting jar should work as before on Java 8. I cannot test Java 9 and 10, but to actually run on Java 11, more tweaks are needed.

I tried to test this with the fxldemo project, and both jars (= compiled with JDK 8 vs JDK 11) work the same when run under JDK 8. I get an error "WARNING: Error during Update Manifest phase" when I replace the original fxlauncher.jar with the new SNAPSHOT version though. But I see the same error when replaing with the original SNAPSHOT version (not containing my changes), so this seems unrelated.

When running on JDK 11, I get this error:

    Error: Could not find or load main class fxlauncher.Launcher
    Caused by: java.lang.NoClassDefFoundError: javafx/application/Application

I will look into the issue with running under Java 11 later.
